### PR TITLE
Fix typo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import 'tinymce'
 
 // Apps
 
-import './types/applications/app'
+import './types/applications/application'
 import './types/applications/button'
 import './types/applications/baseEntitySheet'
 import './types/applications/form'


### PR DESCRIPTION
Without this change `tsc` on my module fails with the error `TS2339: Property 'render' does not exist on type 'MyDialog'.`