### PR TITLE
Adjust Application.Position to match what foundry uses and add new ty…

### DIFF
--- a/types/applications/application.d.ts
+++ b/types/applications/application.d.ts
@@ -424,7 +424,7 @@ declare class Application<T = object> {
    * @param scale  - The application scale as a numeric factor where 1.0 is default
    * @returns The updated position object for the application containing the new values
    */
-  setPosition (appPos?: Partial<Application.Position>): Application.Position
+  setPosition (appPos?: Application.PositionParameter): Application.Position
 
   /* -------------------------------------------- */
 
@@ -566,11 +566,19 @@ declare namespace Application {
   }
 
   interface Position {
-    width: number | 'auto'
-    height: number | 'auto'
+    width: number
+    height: number
     left: number
     top: number
     scale: number
+  }
+
+  interface PositionParameter {
+    width?: number
+    height?: number | 'auto'
+    left?: number
+    top?: number
+    scale?: number
   }
 
   interface RenderOptions {


### PR DESCRIPTION
…pe for parameter of Application.setPosition

`Application.Position`, the type of `Application.position` and the return type of `Application.setPosition` can only have numbers as fields. `'auto'` can only be passed as the `height` in `Application.setPosition(...)`